### PR TITLE
Use unpacked encoding in the EIP-712 `hashStruct` method

### DIFF
--- a/packages/common-ts/src/attestations/attestations.test.ts
+++ b/packages/common-ts/src/attestations/attestations.test.ts
@@ -28,9 +28,9 @@ describe('Attestations', () => {
       requestCID: receipt.requestCID,
       responseCID: receipt.responseCID,
       subgraphID: receipt.subgraphID,
-      v: 28,
-      r: '0x5eb1e2428518b5fac8904e3239b6bda39cd52ecd054b271b94ae6145976c4ef3',
-      s: '0x38f0f5c725bef4c799d440a2b846d09ab268b23fd363964445643267d789cfd2',
+      v: 27,
+      r: '0x888890e355b6a8239b39bdb2ce1b6642e59fc5591ecaece4ae5704883aa63419',
+      s: '0x625445ed8831ca150f47742dd2925a413227cf5972fddf0549d33253ff1587c9',
     })
   })
 })

--- a/packages/common-ts/src/attestations/eip712.ts
+++ b/packages/common-ts/src/attestations/eip712.ts
@@ -1,4 +1,4 @@
-import { solidityKeccak256, defaultAbiCoder, keccak256, toUtf8Bytes } from 'ethers/utils'
+import { defaultAbiCoder, keccak256, toUtf8Bytes } from 'ethers/utils'
 
 // Hashes a type signature based on the `typeHash` defined on
 // https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md#definition-of-hashstruct.
@@ -19,7 +19,9 @@ const encodeData = (types: string[], values: any[]): string =>
 //
 // NOTE: Does not support recursion yet.
 export const hashStruct = (typeHash: string, types: string[], values: any[]): string =>
-  solidityKeccak256(['bytes32', 'bytes'], [typeHash, encodeData(types, values)])
+  keccak256(
+    defaultAbiCoder.encode(['bytes32', 'bytes'], [typeHash, encodeData(types, values)]),
+  )
 
 const EIP712_DOMAIN_TYPE_HASH = typeHash(
   'EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,bytes32 salt)',


### PR DESCRIPTION
@pedrouid Made me aware that there's a difference in the `hashStruct` implementations in Solidity and in common-ts. I updated common-ts to match the one in Solidity. For reference, see https://github.com/connext/indra/pull/1164/files.