### PR TITLE
Update attestation and receipt attributes to subgraphDeploymentID

### DIFF
--- a/packages/common-ts/src/attestations/attestations.test.ts
+++ b/packages/common-ts/src/attestations/attestations.test.ts
@@ -11,7 +11,7 @@ describe('Attestations', () => {
     let receipt = {
       requestCID: '0xd902c18a1b3590a3d2a8ae4439db376764fda153ca077e339d0427bf776bd463',
       responseCID: '0xbe0b5ae5f598fdf631133571d59ef16b443b2fe02e35ca2cb807158069009db9',
-      subgraphID: hexlify(
+      subgraphDeploymentID: hexlify(
         bs58.decode('QmTXzATwNfgGVukV1fX2T6xw9f6LAYRVWpsdXyRWzUR2H9').slice(2),
       ),
     }
@@ -27,10 +27,10 @@ describe('Attestations', () => {
     expect(attestation).toStrictEqual({
       requestCID: receipt.requestCID,
       responseCID: receipt.responseCID,
-      subgraphID: receipt.subgraphID,
+      subgraphDeploymentID: receipt.subgraphDeploymentID,
       v: 27,
-      r: '0x10994d2f62aa72f2103b7e1df984b020962092a76ad5e8de418e89d0f41bfdb7',
-      s: '0x25c22a538c531c1062821909b9af94166dfe9357c968c20bcc26ec6feb9e315e',
+      r: '0x00bd2f5c3dd7a81dc36a6bf109e4deba55220c0badd5d6e2e1b3aefb48d647e4',
+      s: '0x34ca501c609bef062785671d594be732ef7af1ddbaffd8f3257a2ad606479769',
     })
   })
 })

--- a/packages/common-ts/src/attestations/attestations.ts
+++ b/packages/common-ts/src/attestations/attestations.ts
@@ -2,13 +2,13 @@ import { keccak256, toUtf8Bytes, SigningKey, Arrayish, HDNode } from 'ethers/uti
 import * as eip712 from './eip712'
 
 const RECEIPT_TYPE_HASH = eip712.typeHash(
-  'Receipt(bytes32 requestCID,bytes32 responseCID,bytes32 subgraphID)',
+  'Receipt(bytes32 requestCID,bytes32 responseCID,bytes32 subgraphDeploymentID)',
 )
 
 export interface Receipt {
   requestCID: string
   responseCID: string
-  subgraphID: string
+  subgraphDeploymentID: string
 }
 
 const SALT = '0xa070ffb1cd7409649bf77822cce74495468e06dbfaef09556838bf188679b9c2'
@@ -17,13 +17,13 @@ const encodeReceipt = (receipt: Receipt): string =>
   eip712.hashStruct(
     RECEIPT_TYPE_HASH,
     ['bytes32', 'bytes32', 'bytes32'],
-    [receipt.requestCID, receipt.responseCID, receipt.subgraphID],
+    [receipt.requestCID, receipt.responseCID, receipt.subgraphDeploymentID],
   )
 
 export interface Attestation {
   requestCID: string
   responseCID: string
-  subgraphID: string
+  subgraphDeploymentID: string
   v: number
   r: string
   s: string
@@ -51,7 +51,7 @@ export const createAttestation = async (
   return {
     requestCID: receipt.requestCID,
     responseCID: receipt.responseCID,
-    subgraphID: receipt.subgraphID,
+    subgraphDeploymentID: receipt.subgraphDeploymentID,
     v: v!,
     r,
     s,


### PR DESCRIPTION
This version of the attestation and receipt is used by https://github.com/graphprotocol/contracts/pull/214