### PR TITLE
Switch to flat exports; nested modules are a pain to use

### DIFF
--- a/packages/common-ts/src/index.ts
+++ b/packages/common-ts/src/index.ts
@@ -1,19 +1,8 @@
-import * as logging from './logging'
-import * as metrics from './metrics'
-import * as database from './database'
-import * as stateChannels from './state-channels'
-import * as attestations from './attestations'
-import * as contracts from './contracts'
-import * as subgraph from './subgraph'
-import * as subgraphs from './subgraphs'
-
-export {
-  logging,
-  metrics,
-  database,
-  stateChannels,
-  attestations,
-  contracts,
-  subgraph,
-  subgraphs,
-}
+export * from './logging'
+export * from './metrics'
+export * from './database'
+export * from './state-channels'
+export * from './attestations'
+export * from './contracts'
+export * from './subgraph'
+export * from './subgraphs'

--- a/packages/common-ts/src/metrics/index.ts
+++ b/packages/common-ts/src/metrics/index.ts
@@ -1,7 +1,7 @@
 import prometheus, { collectDefaultMetrics, Registry } from 'prom-client'
 import express from 'express'
 import { Server } from 'net'
-import { logging } from '..'
+import { Logger } from '..'
 
 export interface Metrics {
   client: typeof prometheus
@@ -15,7 +15,7 @@ export const createMetrics = (): Metrics => {
 }
 
 export interface MetricsServerOptions {
-  logger: logging.Logger
+  logger: Logger
   registry: Registry
 }
 


### PR DESCRIPTION
The title says it all. It was a pain to do things like

```ts
import { subgraphs } from '@graphprotocol/common-ts'
...
let deploymentId = new subgraphs.SubgraphDeploymentID("Qm...")
```
with imports such as `subgraphs` or `contracts` almost always colliding with local variable names. And having no way of e.g. importing the `SubgraphDeploymentID` type directly other than
```ts
import { SubgraphDeploymentID } from '@graphprotocol/common-ts/dist/subgraphs'
```
with that ugly `dist/` folder in the mix also sucked.