### PR TITLE
Serve metrics from /metrics by default (customizable)

### DIFF
--- a/packages/common-ts/src/metrics/index.test.ts
+++ b/packages/common-ts/src/metrics/index.test.ts
@@ -34,7 +34,7 @@ describe('Metrics', () => {
       gauge.set(100)
 
       // Verify that the registered metrics are served at `/`
-      const response = await request(server).get('/').send()
+      const response = await request(server).get('/metrics').send()
       expect(response.status).toEqual(200)
       expect(response.text).toMatch(/counter 2/)
       expect(response.text).toMatch(/gauge 100/)

--- a/packages/common-ts/src/metrics/index.ts
+++ b/packages/common-ts/src/metrics/index.ts
@@ -24,6 +24,7 @@ export interface MetricsServerOptions {
   logger: Logger
   registry: Registry
   port?: number
+  route?: string
 }
 
 export const createMetricsServer = (options: MetricsServerOptions): Server => {
@@ -31,7 +32,7 @@ export const createMetricsServer = (options: MetricsServerOptions): Server => {
 
   const app = express()
 
-  app.get('/', (_, res) => {
+  app.get(options.route || '/metrics', (_, res) => {
     res.status(200).send(options.registry.metrics())
   })
 


### PR DESCRIPTION
People have rightfully asked why the metrics aren't served from `/metrics` by default, since that is the default Prometheus scrape path (`metrics_path`).