### PR TITLE
build(contracts): add GRTAssetHolder to NetworkContracts

### DIFF
--- a/packages/common-ts/package.json
+++ b/packages/common-ts/package.json
@@ -15,7 +15,7 @@
     "test:watch": "jest --watch --passWithNoTests --detectOpenHandles --verbose"
   },
   "dependencies": {
-    "@graphprotocol/contracts": "0.7.7-testnet-phase2",
+    "@graphprotocol/contracts": "0.7.9-testnet-phase2",
     "@urql/core": "1.13.1",
     "@urql/exchange-execute": "1.0.1",
     "body-parser": "1.19.0",

--- a/packages/common-ts/src/contracts/index.ts
+++ b/packages/common-ts/src/contracts/index.ts
@@ -14,6 +14,8 @@ import { RewardsManager } from '@graphprotocol/contracts/dist/typechain/contract
 import { ServiceRegistry } from '@graphprotocol/contracts/dist/typechain/contracts/ServiceRegistry'
 import { Staking } from '@graphprotocol/contracts/dist/typechain/contracts/Staking'
 import { GraphToken } from '@graphprotocol/contracts/dist/typechain/contracts/GraphToken'
+import { GrtAssetHolder } from '@graphprotocol/contracts/dist/typechain/contracts/GrtAssetHolder'
+import { AttestationApp } from '@graphprotocol/contracts/dist/typechain/contracts/AttestationApp'
 
 // Contract factories
 import { CurationFactory } from '@graphprotocol/contracts/dist/typechain/contracts/CurationFactory'
@@ -24,10 +26,12 @@ import { RewardsManagerFactory } from '@graphprotocol/contracts/dist/typechain/c
 import { ServiceRegistryFactory } from '@graphprotocol/contracts/dist/typechain/contracts/ServiceRegistryFactory'
 import { StakingFactory } from '@graphprotocol/contracts/dist/typechain/contracts/StakingFactory'
 import { GraphTokenFactory } from '@graphprotocol/contracts/dist/typechain/contracts/GraphTokenFactory'
-import { GRTAssetHolder } from '@graphprotocol/contracts/dist/typechain/contracts/GRTAssetHolder'
+import { GrtAssetHolderFactory } from '@graphprotocol/contracts/dist/typechain/contracts/GrtAssetHolderFactory'
+import { AttestationAppFactory } from '@graphprotocol/contracts/dist/typechain/contracts/AttestationAppFactory'
 
 export interface NetworkContracts {
-  assetHolder: GRTAssetHolder
+  assetHolder: GrtAssetHolder
+  attestationApp: AttestationApp
   curation: Curation
   disputeManager: DisputeManager
   epochManager: EpochManager
@@ -45,8 +49,12 @@ export const connectContracts = async (
   const deployedContracts = DEPLOYED_CONTRACTS[`${chainId}`]
 
   return {
-    assetHolder: GRTAssetHolder.connect(
-      deployedContracts.GRTAssetHolder.address,
+    assetHolder: GrtAssetHolderFactory.connect(
+      deployedContracts.GrtAssetHolder.address,
+      providerOrSigner,
+    ),
+    attestationApp: AttestationAppFactory.connect(
+      deployedContracts.AttestationApp.address,
       providerOrSigner,
     ),
     curation: CurationFactory.connect(

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,10 +699,10 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@graphprotocol/contracts@0.7.7-testnet-phase2":
-  version "0.7.7-testnet-phase2"
-  resolved "https://registry.npmjs.org/@graphprotocol/contracts/-/contracts-0.7.7-testnet-phase2.tgz#629be9c6b8eb2adf539be11fa35fe56a467e3cd6"
-  integrity sha512-79l1Mj9cfwfAjPnDxeDZTKpwQdUjn6D2O03mz4lLifkn5hclY9fKVmugvhrNREiNCQy68koelP3bcYgc4H8ojg==
+"@graphprotocol/contracts@0.7.9-testnet-phase2":
+  version "0.7.9-testnet-phase2"
+  resolved "https://registry.yarnpkg.com/@graphprotocol/contracts/-/contracts-0.7.9-testnet-phase2.tgz#cdeba6361e906fe7a44d596a61f514c9da52bcc2"
+  integrity sha512-qgzAIcYqARP7fIO3WmKNZuDuVxcPeg/BT1uBdBH0n87dRmLQyXxycYsMR50uZEf46Q7gmASHKS/3xAYBiQMP8w==
   dependencies:
     "@ethersproject/contracts" "^5.0.3"
     ethers "^5.0.9"


### PR DESCRIPTION
This will be imported by the `gateway` and `indexer` and provided to the `payment-manager` and `receipt-manager` respectively to ensure channels are using this asset holder for the funds allocated to them.
