### PR TITLE
Fix `join` eventual not detecting value changes correctly

### DIFF
--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -1,4 +1,4 @@
-import { join, mutable } from '../eventual'
+import { join, mutable, timer } from '../eventual'
 
 describe('Eventual', () => {
   test('Value', async () => {
@@ -250,5 +250,18 @@ describe('Eventual', () => {
       numbers: [1, 2],
       delayed: 'ready now',
     })
+  })
+
+  test('Join (timer)', async () => {
+    const ticker = timer(100)
+    const ticks = ticker.reduce(n => ++n, 0)
+    const ticksViaJoin = join({ ticker }).reduce(n => ++n, 0)
+
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // We should have seen 9-10 timer events, but as long as we've seen a few
+    // we're happy
+    await expect(ticks.value()).resolves.toBeGreaterThan(5)
+    await expect(ticksViaJoin.value()).resolves.toBeGreaterThan(5)
   })
 })

--- a/packages/common-ts/src/eventual/eventual.ts
+++ b/packages/common-ts/src/eventual/eventual.ts
@@ -250,7 +250,10 @@ export function join<T>(sources: NamedEventuals<T>): Join<T> {
       sourceValues[key] = value
 
       if (!keys.some(key => sourceValues[key] === undefined)) {
-        output.push(sourceValues)
+        // NOTE: creating a new JS object is important, otherwise
+        // `output.inner` and `sourceValues` will be the same object
+        // and therefore always be considered identical
+        output.push({ ...sourceValues })
       }
     })
   }


### PR DESCRIPTION
`join` needs to create a new object "pointer' when pushing values into its output eventual, otherwise changes to the object would not be properly identified and pushed into subscribers. I added a timer-based test that failed due to this fix and now passes.