### PR TITLE
Add async values() generator for eventuals

### DIFF
--- a/packages/common-ts/CHANGELOG.md
+++ b/packages/common-ts/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add `values()` async generator for eventuals
 
 ## [1.3.3] - 2021-04-04
 ### Changed

--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -309,7 +309,7 @@ describe('Eventual', () => {
     }
 
     let i = 0
-    for await (const value of numbers.values(0)) {
+    for await (const value of numbers.values()) {
       expect(value).toStrictEqual(values[i++])
       if (i >= 100) {
         break

--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -1,4 +1,4 @@
-import { join, mutable, timer, WritableEventual } from '../eventual'
+import { Eventual, join, mutable, timer, WritableEventual } from '../eventual'
 
 describe('Eventual', () => {
   test('Value', async () => {
@@ -296,5 +296,26 @@ describe('Eventual', () => {
     // we're happy
     await expect(ticks.value()).resolves.toBeGreaterThan(5)
     await expect(ticksViaJoin.value()).resolves.toBeGreaterThan(5)
+  })
+
+  test('Values (async generator)', async () => {
+    const values = Array.from(Array(100).keys())
+
+    const numbers = mutable()
+    for (const value of values) {
+      setTimeout(() => {
+        numbers.push(value)
+      }, 50 + value * 50)
+    }
+
+    let i = 0
+    for await (const value of numbers.values(0)) {
+      expect(value).toStrictEqual(values[i++])
+      if (i >= 100) {
+        break
+      }
+    }
+
+    expect(i).toStrictEqual(100)
   })
 })

--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -301,21 +301,18 @@ describe('Eventual', () => {
   test('Values (async generator)', async () => {
     const values = Array.from(Array(100).keys())
 
-    const numbers = mutable()
+    const numbers: WritableEventual<number> = mutable()
     for (const value of values) {
-      setTimeout(() => {
-        numbers.push(value)
-      }, 50 + value * 50)
+      setTimeout(() => numbers.push(value), 50 + value * 20)
     }
 
-    let i = 0
+    let prev = -1
     for await (const value of numbers.values()) {
-      expect(value).toStrictEqual(values[i++])
-      if (i >= 100) {
+      expect(value).toBeGreaterThan(prev)
+      prev = value
+      if (value >= 99) {
         break
       }
     }
-
-    expect(i).toStrictEqual(100)
   })
 })

--- a/packages/common-ts/src/eventual/eventual.ts
+++ b/packages/common-ts/src/eventual/eventual.ts
@@ -37,7 +37,7 @@ export interface Eventual<T> {
   pipe(f: (t: T) => Awaitable<void>): void
   throttle(interval: number): Eventual<T>
   reduce<U>(f: Reducer<T, U>, initial: U): Eventual<U>
-  values(interval: number): AsyncGenerator<T, never, void>
+  values(): AsyncGenerator<T, never, void>
 }
 
 export interface WritableEventual<T> extends Eventual<T> {


### PR DESCRIPTION
A small addition to allow subscribing to an eventual in e.g. GraphQL subscriptions, where an async iterator/generator is expected (at least in graphql-ws).