### PR TITLE
Fix missing current value in async eventual `values()` generator

### DIFF
--- a/packages/common-ts/CHANGELOG.md
+++ b/packages/common-ts/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add `values()` async generator for eventuals
 
+### Fixed
+- Fix missing current value in async eventual `values()` generator
+
 ## [1.3.3] - 2021-04-04
 ### Changed
 - Update ethers to 5.1.0

--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -1,4 +1,4 @@
-import { Eventual, join, mutable, timer, WritableEventual } from '../eventual'
+import { join, mutable, timer, WritableEventual } from '../eventual'
 
 describe('Eventual', () => {
   test('Value', async () => {
@@ -314,5 +314,14 @@ describe('Eventual', () => {
         break
       }
     }
+  })
+
+  test('Values (async generator, subscribed after last value)', async () => {
+    const numbers: WritableEventual<number> = mutable(0)
+    numbers.push(1)
+    await expect(numbers.values().next()).resolves.toStrictEqual({
+      done: false,
+      value: 1,
+    })
   })
 })

--- a/packages/common-ts/src/eventual/eventual.ts
+++ b/packages/common-ts/src/eventual/eventual.ts
@@ -147,12 +147,20 @@ export class EventualValue<T> implements WritableEventual<T> {
     // Create the initial promise
     let next = defer()
 
-    // Whenever there is a new value, resolve the current promise
-    // and replace it with a new one
-    this.pipe(t => {
-      next.resolve(t)
-      next = defer()
-    })
+    // Delay this ever so slightly to allow `await next.promise` to be executed
+    // before we resolve the first value. Otherwise we'd skip the value at the
+    // time `values()` is called, because `await next.promise` would await the
+    // second, not the initial promise.
+    setTimeout(
+      () =>
+        // Whenever there is a new value, resolve the current promise
+        // and replace it with a new one
+        this.pipe(t => {
+          next.resolve(t)
+          next = defer()
+        }),
+      0,
+    )
 
     while (true) {
       yield await next.promise


### PR DESCRIPTION
This fixes a bug where `values()` wouldn't include the current value at the time it is called to obtain an async generator over eventual values.