### PR TITLE
refactor: Add an `intervalID` to `timer` return type

### DIFF
--- a/packages/common-ts/src/eventual/__tests__/eventual.ts
+++ b/packages/common-ts/src/eventual/__tests__/eventual.ts
@@ -286,7 +286,7 @@ describe('Eventual', () => {
   })
 
   test('Join (timer)', async () => {
-    const ticker = timer(100)
+    const [intervalID, ticker] = timer(100)
     const ticks = ticker.reduce(n => ++n, 0)
     const ticksViaJoin = join({ ticker }).reduce(n => ++n, 0)
 
@@ -296,6 +296,7 @@ describe('Eventual', () => {
     // we're happy
     await expect(ticks.value()).resolves.toBeGreaterThan(5)
     await expect(ticksViaJoin.value()).resolves.toBeGreaterThan(5)
+    clearInterval(intervalID)
   })
 
   test('Values (async generator)', async () => {

--- a/packages/common-ts/src/eventual/eventual.ts
+++ b/packages/common-ts/src/eventual/eventual.ts
@@ -286,10 +286,10 @@ export function throttle<T>(source: Eventual<T>, interval: number): Eventual<T> 
   return output
 }
 
-export function timer(milliseconds: number): Eventual<number> {
+export function timer(milliseconds: number): [NodeJS.Timer, Eventual<number>] {
   const time = mutable(Date.now())
-  setInterval(() => time.push(Date.now()), milliseconds)
-  return time
+  const intervalID = setInterval(() => time.push(Date.now()), milliseconds)
+  return [intervalID, time]
 }
 
 export function reduce<T, U>(


### PR DESCRIPTION
This commit modifies the `timer` function to return a tuple with the [`timeout` object](https://nodejs.org/api/timers.html#class-timeout) returned by the call to `setInterval` alongside the `Eventual<number>` timer. 

Users could then cancel the timer with `cancelInterval(timeout)` or make it unblock the main Node process with `timeout.unref()`.

This pull request aims to fix an issue where the Indexer Agent tests keep the NodeJS process alive after completing the tests and tearing down resources (like the DB). This causes the process to exit with a non-zero code since the program execution tied to such timers relies on those resources.