### PR TITLE
Don't build test files

### DIFF
--- a/packages/common-ts/tsconfig.json
+++ b/packages/common-ts/tsconfig.json
@@ -13,6 +13,6 @@
     "lib": ["es2015", "es6", "esnext.asynciterable", "dom"],
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/__tests__/*.ts"],
+  "exclude": ["src/**/__tests__/*.ts", "src/**/*.test.ts"],
   "references": []
 }


### PR DESCRIPTION
Extends `tsc` exclusion pattern to ignore test files named `*.test.ts`.