### PR TITLE
[db] add ability to enable SSL for database connection

### DIFF
--- a/packages/common-ts/CHANGELOG.md
+++ b/packages/common-ts/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add ability to enable SSL to database connection with `sslEnabled` (maintain default of `false`)
 
 ## [2.0.7] - 2023-09-25
 ### Changed

--- a/packages/common-ts/src/database/index.test.ts
+++ b/packages/common-ts/src/database/index.test.ts
@@ -10,4 +10,45 @@ describe('Database', () => {
     const sequelize = await connectDatabase(__DATABASE__)
     expect(sequelize).toBeDefined()
   })
+
+  test('Connect with options set', async () => {
+    const sequelize = await connectDatabase({
+      host: 'localhost',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      sslEnabled: true,
+      logging: () => {},
+      poolMin: 1,
+      poolMax: 5,
+    })
+
+    expect(sequelize).toBeDefined()
+
+    const poolConfig = sequelize.config.pool
+    expect(poolConfig?.min).toBe(1)
+    expect(poolConfig?.max).toBe(5)
+
+    const sslConfig = sequelize.config.ssl
+    expect(sslConfig).toBe(true)
+  })
+
+  test('Connect with default options', async () => {
+    const sequelize = await connectDatabase({
+      host: 'localhost',
+      username: 'test',
+      password: 'test',
+      database: 'test',
+      logging: () => {},
+    })
+
+    expect(sequelize).toBeDefined()
+
+    const poolConfig = sequelize.config.pool
+    expect(poolConfig?.min).toBe(0)
+    expect(poolConfig?.max).toBe(10)
+
+    const sslConfig = sequelize.config.ssl
+    expect(sslConfig).toBe(false)
+  })
 })

--- a/packages/common-ts/src/database/index.ts
+++ b/packages/common-ts/src/database/index.ts
@@ -6,6 +6,7 @@ interface ConnectOptions {
   username: string
   password: string
   database: string
+  sslEnabled?: boolean
   logging?: (sql: string, timing?: number) => void
   poolMin?: number
   poolMax?: number
@@ -18,6 +19,7 @@ export const connectDatabase = async (options: ConnectOptions): Promise<Sequeliz
   const port = options.port || 5432
   const poolMin = options.poolMin || 0
   const poolMax = options.poolMax || 10
+  const sslEnabled = options.sslEnabled || false
 
   // Connect to the database
   const sequelize = new Sequelize({
@@ -27,6 +29,7 @@ export const connectDatabase = async (options: ConnectOptions): Promise<Sequeliz
     username,
     password,
     database,
+    ssl: sslEnabled,
     pool: {
       max: poolMax,
       min: poolMin,


### PR DESCRIPTION
* Adds the ability to enable SSL for the database connection.
* Maintains existing default behavior of *not* being enabled.
* Adds tests for setting options and default options on the database connection.

--

Ran tests locally and they pass as expected:
```
$ POSTGRES_TEST_DATABASE=test POSTGRES_TEST_PASSWORD=test POSTGRES_TEST_USERNAME=test POSTGRES_TEST_HOST=localhost yarn test
```

Once this is merged, I intend to open PRs for `graphprotocol/indexer` to update if accepted.

Thank you.